### PR TITLE
Compile RocksDB with snappy 1.1.9 support enabled

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -136,3 +136,6 @@
 [submodule "libraries/cmake/source/libcap/src"]
 	path = libraries/cmake/source/libcap/src
 	url = https://kernel.googlesource.com/pub/scm/libs/libcap/libcap.git
+[submodule "libraries/cmake/source/snappy/src"]
+	path = libraries/cmake/source/snappy/src
+	url = https://github.com/google/snappy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,6 +114,7 @@ function(importLibraries)
     "Linux,Darwin:popt"
     "Linux,Darwin,Windows:rapidjson"
     "Linux,Darwin,Windows:rocksdb"
+    "Linux,Darwin,Windows:snappy"
     "Linux,Darwin,Windows:sleuthkit"
     "Linux,Darwin:smartmontools"
     "Linux,Darwin,Windows:sqlite"

--- a/libraries/cmake/source/modules/Findsnappy.cmake
+++ b/libraries/cmake/source/modules/Findsnappy.cmake
@@ -1,0 +1,15 @@
+# Copyright (c) 2014-present, The osquery authors
+#
+# This source code is licensed as defined by the LICENSE file found in the
+# root directory of this source tree.
+#
+# SPDX-License-Identifier: (Apache-2.0 OR GPL-2.0-only)
+
+include("${CMAKE_CURRENT_LIST_DIR}/utils.cmake")
+
+importSourceSubmodule(
+  NAME "snappy"
+
+  SHALLOW_SUBMODULES
+    "src"
+)

--- a/libraries/cmake/source/rocksdb/CMakeLists.txt
+++ b/libraries/cmake/source/rocksdb/CMakeLists.txt
@@ -345,10 +345,12 @@ function(rocksdbMain)
 
     ROCKSDB_NO_DYNAMIC_EXTENSION
     ROCKSDB_SUPPORT_THREAD_LOCAL
+    SNAPPY
   )
 
   target_link_libraries(thirdparty_rocksdb PRIVATE
     thirdparty_cxx_settings
+    thirdparty_snappy
   )
 
   target_include_directories(thirdparty_rocksdb PRIVATE

--- a/libraries/cmake/source/snappy/CMakeLists.txt
+++ b/libraries/cmake/source/snappy/CMakeLists.txt
@@ -1,0 +1,32 @@
+# Copyright (c) 2014-present, Facebook, Inc.
+# All rights reserved.
+#
+# This source code is licensed in accordance with the terms specified in
+# the LICENSE file found in the root directory of this source tree.
+
+function(snappyMain)
+  set(library_root "${CMAKE_CURRENT_SOURCE_DIR}/src")
+
+  add_library(thirdparty_snappy
+    "${library_root}/snappy-internal.h"
+    "${library_root}/snappy-stubs-internal.h"
+    "${library_root}/snappy-c.cc"
+    "${library_root}/snappy-sinksource.cc"
+    "${library_root}/snappy-stubs-internal.cc"
+    "${library_root}/snappy.cc"
+  )
+
+  target_link_libraries(thirdparty_snappy PRIVATE
+    thirdparty_c_settings
+  )
+
+  target_include_directories(thirdparty_snappy PRIVATE
+    "${library_root}"
+  )
+
+  target_include_directories(thirdparty_snappy SYSTEM INTERFACE
+    "${library_root}"
+  )
+endfunction()
+
+snappyMain()


### PR DESCRIPTION
This allows us to load existing osquery db files created on Arch Linux instead of recreating the db and thus creating new device identifiers.
See: https://bugs.archlinux.org/task/72251

As discussed, this adds Snappy as a source-dependency (v1.1.9) and allows us to compile RocksDB with Snappy compression support.

I'm not sure how easy it is to patch a new Git submodule in the PKGBUILD.

Possible alternatives I would not take:
1. Do not add Snappy as source-dependency but use the library present in Arch Linux.
2. Load the RocksDB library present in Arch Linux.

I see this patch temporarily and we should think about getting the Arch-specific DB support either upstream or think about a migration. But in order to fix the 5.0.1 Arch Linux package I don't see any quick alternatives.